### PR TITLE
Upgrade terraform to v0.15.3

### DIFF
--- a/environments/dev/backend.tf
+++ b/environments/dev/backend.tf
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 terraform {
   backend "gcs" {
     bucket = "PROJECT_ID-tfstate"

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -14,27 +14,27 @@
 
 
 locals {
-  "env" = "dev"
+  env = "dev"
 }
 
 provider "google" {
-  project = "${var.project}"
+  project = var.project
 }
 
 module "vpc" {
   source  = "../../modules/vpc"
-  project = "${var.project}"
-  env     = "${local.env}"
+  project = var.project
+  env     = local.env
 }
 
 module "http_server" {
   source  = "../../modules/http_server"
-  project = "${var.project}"
-  subnet  = "${module.vpc.subnet}"
+  project = var.project
+  subnet  = module.vpc.subnet
 }
 
 module "firewall" {
   source  = "../../modules/firewall"
-  project = "${var.project}"
-  subnet  = "${module.vpc.subnet}"
+  project = var.project
+  subnet  = module.vpc.subnet
 }

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -12,23 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 output "network" {
-  value = "${module.vpc.network}"
+  value = module.vpc.network
 }
 
 output "subnet" {
-  value = "${module.vpc.subnet}"
+  value = module.vpc.subnet
 }
 
 output "firewall_rule" {
-  value = "${module.firewall.firewall_rule}"
+  value = module.firewall.firewall_rule
 }
 
 output "instance_name" {
-  value = "${module.http_server.instance_name}"
+  value = module.http_server.instance_name
 }
 
 output "external_ip" {
-  value = "${module.http_server.external_ip}"
+  value = module.http_server.external_ip
 }

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 variable "project" {}

--- a/environments/dev/versions.tf
+++ b/environments/dev/versions.tf
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 terraform {
-  required_version = "~> 0.11.0"
+  required_version = "~> 0.15.3"
 }

--- a/environments/prod/backend.tf
+++ b/environments/prod/backend.tf
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 terraform {
   backend "gcs" {
     bucket = "PROJECT_ID-tfstate"

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -14,27 +14,27 @@
 
 
 locals {
-  "env" = "prod"
+  env = "prod"
 }
 
 provider "google" {
-  project = "${var.project}"
+  project = var.project
 }
 
 module "vpc" {
   source  = "../../modules/vpc"
-  project = "${var.project}"
-  env     = "${local.env}"
+  project = var.project
+  env     = local.env
 }
 
 module "http_server" {
   source  = "../../modules/http_server"
-  project = "${var.project}"
-  subnet  = "${module.vpc.subnet}"
+  project = var.project
+  subnet  = module.vpc.subnet
 }
 
 module "firewall" {
   source  = "../../modules/firewall"
-  project = "${var.project}"
-  subnet  = "${module.vpc.subnet}"
+  project = var.project
+  subnet  = module.vpc.subnet
 }

--- a/environments/prod/outputs.tf
+++ b/environments/prod/outputs.tf
@@ -14,21 +14,21 @@
 
 
 output "network" {
-  value = "${module.vpc.network}"
+  value = module.vpc.network
 }
 
 output "subnet" {
-  value = "${module.vpc.subnet}"
+  value = module.vpc.subnet
 }
 
 output "firewall_rule" {
-  value = "${module.firewall.firewall_rule}"
+  value = module.firewall.firewall_rule
 }
 
 output "instance_name" {
-  value = "${module.http_server.instance_name}"
+  value = module.http_server.instance_name
 }
 
 output "external_ip" {
-  value = "${module.http_server.external_ip}"
+  value = module.http_server.external_ip
 }

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 variable "project" {}

--- a/environments/prod/versions.tf
+++ b/environments/prod/versions.tf
@@ -14,5 +14,5 @@
 
 
 terraform {
-  required_version = "~> 0.11.0"
+  required_version = "~> 0.15.3"
 }

--- a/modules/firewall/main.tf
+++ b/modules/firewall/main.tf
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 locals {
-  network = "${element(split("-", var.subnet), 0)}"
+  network = element(split("-", var.subnet), 0)
 }
 
 resource "google_compute_firewall" "allow-http" {
   name    = "${local.network}-allow-http"
-  network = "${local.network}"
-  project = "${var.project}"
+  network = local.network
+  project = var.project
 
   allow {
     protocol = "tcp"

--- a/modules/firewall/outputs.tf
+++ b/modules/firewall/outputs.tf
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 output "firewall_rule" {
-  value = "${google_compute_firewall.allow-http.name}"
+  value = google_compute_firewall.allow-http.name
 }

--- a/modules/firewall/variables.tf
+++ b/modules/firewall/variables.tf
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 variable "project" {}
 variable "subnet" {}

--- a/modules/firewall/versions.tf
+++ b/modules/firewall/versions.tf
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 terraform {
-  required_version = "~> 0.11.0"
+  required_version = "~> 0.15.3"
 }

--- a/modules/http_server/main.tf
+++ b/modules/http_server/main.tf
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 locals {
   network = "${element(split("-", var.subnet), 0)}"
 }

--- a/modules/http_server/outputs.tf
+++ b/modules/http_server/outputs.tf
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 output "instance_name" {
   value = "${google_compute_instance.http_server.name}"
 }

--- a/modules/http_server/variables.tf
+++ b/modules/http_server/variables.tf
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 variable "project" {}
 variable "subnet" {}

--- a/modules/http_server/versions.tf
+++ b/modules/http_server/versions.tf
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 terraform {
-  required_version = "~> 0.11.0"
+  required_version = "~> 0.15.3"
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 module "vpc" {
   source  = "terraform-google-modules/network/google"
-  version = "0.6.0"
+  version = "~> 3.0"
 
-  project_id   = "${var.project}"
-  network_name = "${var.env}"
+  project_id   = var.project
+  network_name = var.env
 
   subnets = [
     {

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 output "network" {
   value = "${module.vpc.network_name}"
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 variable "project" {}
 variable "env" {}

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 terraform {
-  required_version = "~> 0.11.0"
+  required_version = "~> 0.15.3"
 }


### PR DESCRIPTION
This PR updates the modules, fixes deprecation warnings and updates the overall terraform version to 0.15.3.

Also for a bonus it includes some minor linting, which has been done by the official hashicorp terraform vscode plugin.