### PR TITLE
Update modules/http_server/main.tf to debian-11

### DIFF
--- a/modules/http_server/main.tf
+++ b/modules/http_server/main.tf
@@ -27,7 +27,7 @@ resource "google_compute_instance" "http_server" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
     }
   }
 


### PR DESCRIPTION
Requesting an update to debian-11 for boot_disk image family parameters. TF error when using debian-9 image as this is now eol 

https://www.debian.org/releases/stretch/