### PR TITLE
fix: invalid region tags in use

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -48,6 +48,7 @@ steps:
         done
       fi 
 
+# [START cloudbuild-sol-gitops-plan]
 # [START tf-plan]
 - id: 'tf plan'
   name: 'hashicorp/terraform:1.0.0'
@@ -73,7 +74,8 @@ steps:
         done
       fi 
 # [END tf-plan]
-
+# [END cloudbuild-sol-gitops-plan]
+# [START cloudbuild-sol-gitops-apply]
 # [START tf-apply]
 - id: 'tf apply'
   name: 'hashicorp/terraform:1.0.0'
@@ -89,4 +91,5 @@ steps:
         echo "Branch '$BRANCH_NAME' does not represent an official environment."
         echo "*******************************************************************************"
       fi
-# [END tf-apply]      
+# [END tf-apply]
+# [END cloudbuild-sol-gitops-apply]   


### PR DESCRIPTION
@fernandorubbo please take a look; after the region tag PR is merged; we'll need to update https://cloud.google.com/docs/terraform/resource-management/managing-infrastructure-as-code to use the updated region tag, and then we can remove the invalid region tags. 

I'm using cloudbuild as this is cloud build configurations and not terraform that you're wrapping. 